### PR TITLE
Adds tags to backup trials

### DIFF
--- a/capture/noworkflow/now/cmd/cmd_restore.py
+++ b/capture/noworkflow/now/cmd/cmd_restore.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from future.utils import viewitems
 
 from ..collection.metadata import Metascript
-from ..persistence.models import Trial, Module, FileAccess
+from ..persistence.models import Trial, Module, FileAccess, Tag
 from ..persistence.models import CodeComponent, CodeBlock, Argument
 from ..persistence import persistence_config, content
 from ..utils.io import print_msg
@@ -121,6 +121,8 @@ class Restore(Command):
         FileAccess.store(accesses, partial)
         Argument.store(arguments, partial)
         metascript.definition.store_provenance()
+        
+        Tag.create_automatic_tag(tid, None, None, None, metascript.trial.experiment_id, True) # Adds a X.0.0 tag to the backup trial
 
         print_msg("Backup Trial {} created".format(metascript.trial_id),
                   self.print_msg)

--- a/capture/noworkflow/now/persistence/models/tag.py
+++ b/capture/noworkflow/now/persistence/models/tag.py
@@ -156,7 +156,7 @@ class Tag(AlchemyProxy):
         return 0, [1, 1, 1]
 
     @classmethod  # query
-    def create_automatic_tag(cls, trial_id, code_hash, command, session=None, experiment_id=None):
+    def create_automatic_tag(cls, trial_id, code_hash, command, session=None, experiment_id=None, is_backup_trial=False):
         """Create automatic tag for trial id
 
         Find maximum automatic tag by code_hash and command
@@ -214,6 +214,7 @@ class Tag(AlchemyProxy):
             tag[0] += 1
             tag[1] = 1
             tag[2] = 1
+            if is_backup_trial: tag[1] = tag[2] = 0
         new_tag = ".".join(cvmap(str, tag))
 
         cls.create(trial_id, "AUTO", new_tag, datetime.now(), session=session)


### PR DESCRIPTION
Backup trials' tags must be formatted as X.0.0.
After restoring a future trial tag, with changes in the code, must be (X+1).1.1