### PR TITLE
Downgrade werkzeug to fix incompatibility with Flask 2.1.3

### DIFF
--- a/capture/setup.py
+++ b/capture/setup.py
@@ -55,9 +55,9 @@ setup(
         "requests", "ipykernel",
     ],
     extras_require={
-        "demo": ["flask==2.1.3", "matplotlib>=3.5.3,<3.6", "numpy>=1.21.6,<1.22", "cython"],
+        "demo": ["flask==2.1.3", "werkzeug==2.3.7", "matplotlib>=3.5.3,<3.6", "numpy>=1.21.6,<1.22", "cython"],
         "notebook": ["pyposast", "ipython", "jupyter"],
-        "all": ["pyposast", "ipython", "jupyter", "flask==2.1.3", "pyswip-alt", 
+        "all": ["pyposast", "ipython", "jupyter", "flask==2.1.3", "werkzeug==2.3.7", "pyswip-alt", 
                 "matplotlib>=3.5.3,<3.6", "numpy>=1.21.6,<1.22", "cython"],
     },
     classifiers=[


### PR DESCRIPTION
I have newly installed noWorkFlow using `pip install capture[demo]` to visualize using `now vis`. 

> . . .
> Collecting flask==2.1.3
>   Using cached Flask-2.1.3-py3-none-any.whl (95 kB)
> Collecting Werkzeug>=2.0
>   Using cached werkzeug-3.0.3-py3-none-any.whl (227 kB)
> . . .

The flask version 2.1.3 then was installed. But I encountered an ImportError instead:

> Traceback (most recent call last):
>   File "C:\Users\LENOVO\AppData\Local\Programs\Python\Python38\Scripts\now-script.py", line 33, in <module>
>     sys.exit(load_entry_point('noworkflow', 'console_scripts', 'now')())
>   File "c:\users\lenovo\onedrive\documents\noworkflow\capture\noworkflow\now\cmd\__init__.py", line 78, in main
>     args.func(args)
>   File "c:\users\lenovo\onedrive\documents\noworkflow\capture\noworkflow\now\cmd\cmd_vis.py", line 56, in execute
>     run(path=args.dir, browser=args.browser, port=args.port,
>   File "c:\users\lenovo\onedrive\documents\noworkflow\capture\noworkflow\now\cmd\cmd_vis.py", line 24, in run    from ..vis.views import app
>   File "c:\users\lenovo\onedrive\documents\noworkflow\capture\noworkflow\now\vis\views.py", line 13, in <module>
>     from flask import render_template, jsonify, request, make_response, send_file,send_file, Response        
>   File "c:\users\lenovo\appdata\local\programs\python\python38\lib\site-packages\flask\__init__.py", line 7, 
> in <module>
>     from .app import Flask as Flask
>   File "c:\users\lenovo\appdata\local\programs\python\python38\lib\site-packages\flask\app.py", line 27, in <module>
>     from . import cli
>   File "c:\users\lenovo\appdata\local\programs\python\python38\lib\site-packages\flask\cli.py", line 17, in <module>
>     from .helpers import get_debug_flag
>   File "c:\users\lenovo\appdata\local\programs\python\python38\lib\site-packages\flask\helpers.py", line 14, 
> in <module>
>     from werkzeug.urls import url_quote
> ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (c:\users\lenovo\appdata\local\programs\python\python38\lib\site-packages\werkzeug\urls.py)

The error stemmed from incompatibility between flask 2.1.3 and werkzeug versions 3.0.3. The [solution](https://stackoverflow.com/a/77214086) was to downgrading werkzeug to version 2.3.7 resolves the issue.

