### PR TITLE
Fix npm package.json missing dependency

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -4624,6 +4624,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/ace-builds": {
+      "version": "1.43.3",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.3.tgz",
+      "integrity": "sha512-MCl9rALmXwIty/4Qboijo/yNysx1r6hBTzG+6n/TiOm5LFhZpEvEIcIITPFiEOEFDfgBOEmxu+a4f54LEFM6Sg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -15811,6 +15817,7 @@
         "@noworkflow/trial": "0.0.8",
         "@noworkflow/utils": "0.0.9",
         "@viz-js/viz": "^3.8.0",
+        "ace-builds": "^1.43.3",
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
         "crypto-browserify": "^3.12.0",
@@ -18247,6 +18254,7 @@
         "@types/d3": "^7.4.3",
         "@types/file-saver": "^2.0.1",
         "@viz-js/viz": "^3.8.0",
+        "ace-builds": "^1.43.3",
         "babel-loader": "^9.1.3",
         "buffer": "^6.0.3",
         "child_process": "^1.0.2",
@@ -19940,6 +19948,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
       "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
       "dev": true
+    },
+    "ace-builds": {
+      "version": "1.43.3",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.3.tgz",
+      "integrity": "sha512-MCl9rALmXwIty/4Qboijo/yNysx1r6hBTzG+6n/TiOm5LFhZpEvEIcIITPFiEOEFDfgBOEmxu+a4f54LEFM6Sg=="
     },
     "acorn": {
       "version": "8.12.1",

--- a/src/frontend/packages/nowvis/package.json
+++ b/src/frontend/packages/nowvis/package.json
@@ -14,6 +14,8 @@
     "@noworkflow/history": "0.0.11",
     "@noworkflow/trial": "0.0.8",
     "@noworkflow/utils": "0.0.9",
+    "@viz-js/viz": "^3.8.0",
+    "ace-builds": "^1.43.3",
     "buffer": "^6.0.3",
     "child_process": "^1.0.2",
     "crypto-browserify": "^3.12.0",
@@ -21,9 +23,8 @@
     "file-saver": "^2.0.5",
     "fs": "^0.0.1-security",
     "stream-browserify": "^3.0.0",
-    "@viz-js/viz": "^3.8.0",
-    "tau-prolog": "^0.3.4",
-    "svg-pan-zoom": "^3.6.1"
+    "svg-pan-zoom": "^3.6.1",
+    "tau-prolog": "^0.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
## Resumo

&emsp;#174 introduz uma nova biblioteca `ace-builds` em `src/frontend/packages/nowvis/src/query_widget.ts`, mas não adiciona a mesma na lista de dependências do projeto dentro de `package.json`. Novas builds e `watch.py` quebram pela falta dessa dependência. 

## Alterações
- `package.json` atualizado;