### PR TITLE
[#178] Pin setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ dependencies = [
     "importlib-metadata==6.4.1",
     "typing-extensions>=4.5.0,<5",
     "setuptools<72",
-    "nbformat",
-    "jupyter-client",
+    "nbformat"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ dependencies = [
     "ipykernel",
     "zipp==3.15",
     "importlib-metadata==6.4.1",
-    "typing-extensions>=4.5.0,<5"
+    "typing-extensions>=4.5.0,<5",
+    "setuptools<72",
+    "nbformat",
+    "jupyter-client",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fix: Cap setuptools <72 to resolve pkg_resources import error.  Fixes [#178](https://github.com/gems-uff/noworkflow/issues/178)
Also adds missing dependency `nbformat` required for fresh installations.
