### PR TITLE
fix Python 3.8 ast export

### DIFF
--- a/src/noworkflow/now/models/ast/trial_ast.py
+++ b/src/noworkflow/now/models/ast/trial_ast.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 
 import weakref
 import ast
+import sys
 
 
 class TrialAst(object):
@@ -661,7 +662,10 @@ class TrialAst(object):
             return ast_
 
     def construct_ast(self):
-        print(ast.dump(ast.parse(self()), indent=2))
+        kwargs = {}
+        if sys.version_info >= (3, 9):
+            kwargs["indent"] = 2
+        print(ast.dump(ast.parse(self()), **kwargs))
 
 def ast_to_dot(node):
     """Converts AST node to DOT format for Graphviz."""

--- a/src/noworkflow/tests/__init__.py
+++ b/src/noworkflow/tests/__init__.py
@@ -22,7 +22,7 @@ persistence_config.mock()
 #from .prov_deployment import TestProvDeployment
 from .prov_definition import TestCodeBlockDefinition
 from .prov_definition import TestCodeComponentDefinition
-from .prov_definition import TestReconstruction
+from .prov_definition import TestReconstruction, TestTrialAst
 from .prov_execution import TestScript, TestStmtExecution, TestExprExecution
 from .prov_execution import TestClassExecution, TestDepthExecution
 from .dependency import TestClusterizer, TestClusterizerConfig
@@ -56,6 +56,7 @@ definition = unittest.TestSuite()
 definition.addTests(loader.loadTestsFromTestCase(TestCodeBlockDefinition))
 definition.addTests(loader.loadTestsFromTestCase(TestCodeComponentDefinition))
 definition.addTests(loader.loadTestsFromTestCase(TestReconstruction))
+definition.addTests(loader.loadTestsFromTestCase(TestTrialAst))
 
 execution = unittest.TestSuite()
 execution.addTests(loader.loadTestsFromTestCase(TestScript))

--- a/src/noworkflow/tests/prov_definition/__init__.py
+++ b/src/noworkflow/tests/prov_definition/__init__.py
@@ -10,9 +10,11 @@ from __future__ import (absolute_import, print_function,
 from .test_code_block_definition import TestCodeBlockDefinition
 from .test_code_component_definition import TestCodeComponentDefinition
 from .test_reconstruction import TestReconstruction
+from .test_trial_ast import TestTrialAst
 
 __all__ = [
     "TestCodeBlockDefinition",
     "TestCodeComponentDefinition",
     "TestReconstruction",
+    "TestTrialAst",
 ]

--- a/src/noworkflow/tests/prov_definition/test_trial_ast.py
+++ b/src/noworkflow/tests/prov_definition/test_trial_ast.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Universidade Federal Fluminense (UFF)
+# Copyright (c) 2026 Polytechnic Institute of New York University.
+# This file is part of noWorkflow.
+# Please, consult the license terms in the LICENSE file.
+"""Test TrialAst output helpers"""
+from __future__ import (absolute_import, print_function,
+                        division, unicode_literals)
+
+import ast
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:  # pragma: no cover
+    import mock
+
+from ...now.models.ast import trial_ast
+
+
+class TestTrialAst(unittest.TestCase):
+    """TestCase for TrialAst"""
+
+    def test_construct_ast_uses_compatible_dump_on_python_38(self):
+        """Do not pass indent to ast.dump on Python 3.8"""
+        module = ast.parse("x = 1")
+        trial_ast_instance = object.__new__(trial_ast.TrialAst)
+
+        with mock.patch.object(trial_ast.TrialAst, "__call__", return_value=module):
+            with mock.patch.object(trial_ast.sys, "version_info", (3, 8, 0)):
+                with mock.patch.object(trial_ast.ast, "parse", return_value=module):
+                    with mock.patch.object(trial_ast.ast, "dump") as dump:
+                        dump.return_value = "Module(...)"
+                        trial_ast_instance.construct_ast()
+
+        dump.assert_called_once_with(module)
+
+    def test_construct_ast_keeps_indented_dump_when_supported(self):
+        """Pass indent to ast.dump on Python 3.9+"""
+        module = ast.parse("x = 1")
+        trial_ast_instance = object.__new__(trial_ast.TrialAst)
+
+        with mock.patch.object(trial_ast.TrialAst, "__call__", return_value=module):
+            with mock.patch.object(trial_ast.sys, "version_info", (3, 9, 0)):
+                with mock.patch.object(trial_ast.ast, "parse", return_value=module):
+                    with mock.patch.object(trial_ast.ast, "dump") as dump:
+                        dump.return_value = "Module(...)"
+                        trial_ast_instance.construct_ast()
+
+        dump.assert_called_once_with(module, indent=2)


### PR DESCRIPTION
Fixes #192

`now export ast` was passing `indent=2` to `ast.dump`, but that kwarg only exists on Python 3.9+. the package still allows Python 3.8, so this keeps the current version floor.

so theses change basically:
- use indented AST output on Python 3.9+
- use plain `ast.dump` on Python 3.8
- add focused tests for both branches