### PR TITLE
Move FileAccessProxy into its own module

### DIFF
--- a/src/noworkflow/now/collection/prov_execution/collector.py
+++ b/src/noworkflow/now/collection/prov_execution/collector.py
@@ -8,7 +8,6 @@
 import sys
 import weakref
 import os
-import io
 import time
 import inspect
 
@@ -29,6 +28,7 @@ from .structures import AssignAccess, Assign, Generator, FutureActivation
 from .structures import DependencyAware, Dependency, Parameter
 from .structures import MemberDependencyAware, CollectionDependencyAware
 from .structures import ConditionExceptions, WithContext
+from .file_access_proxy import wrap_file_access
 
 NOW_UNSET = "<now_unset>"
 
@@ -72,103 +72,6 @@ OPEN_MODES = {
 def is_write_mode(mode):
     """Return True if the open mode writes/modifies the file (w/a/x/+)"""
     return any(char in mode for char in ("w", "a", "x", "+"))
-
-
-class FileAccessProxy(object):
-    """Proxy around a real file object.
-
-    Delegates every operation to the wrapped file and captures
-    ``content_hash_after`` at the moment the file is closed (explicit
-    ``close()`` or ``with`` block exit). This is required because the
-    ``open`` call is itself a noWorkflow activation that closes right after
-    returning the (just-truncated) file object; capturing the "after" hash
-    when that activation closes would always hash an empty file.
-    """
-    # pylint: disable=protected-access
-
-    def __init__(self, file, file_access, collector):
-        object.__setattr__(self, "_f", file)
-        object.__setattr__(self, "_fa", file_access)
-        object.__setattr__(self, "_collector", collector)
-
-    def _capture_after(self):
-        """Re-read the file from disk and store its content_hash_after once"""
-        file_access = self._fa
-        # The file is no longer open for the never-closed fallback in store().
-        self._collector.open_write_files.pop(file_access, None)
-        if (file_access.content_hash_after is None
-                and os.path.exists(file_access.name)):
-            with content.std_open(file_access.name, "rb") as fil:
-                file_access.content_hash_after = content.put(
-                    fil.read(), file_access.name
-                )
-        file_access.done = True
-
-    def close(self):
-        """Close the real file (flushing it) before capturing the hash"""
-        result = self._f.close()
-        self._capture_after()
-        return result
-
-    def __enter__(self):
-        self._f.__enter__()
-        return self
-
-    def __exit__(self, *exc):
-        result = self._f.__exit__(*exc)
-        self._capture_after()
-        return result
-
-    # Dunders that bypass __getattr__ must be delegated explicitly:
-    def __iter__(self):
-        return iter(self._f)
-
-    def __next__(self):
-        return next(self._f)
-
-    def write(self, *args, **kwargs):
-        return self._f.write(*args, **kwargs)
-
-    def read(self, *args, **kwargs):
-        return self._f.read(*args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self._f, name)
-
-    def __setattr__(self, name, value):
-        setattr(self._f, name, value)
-
-
-class TextFileProxy(FileAccessProxy):
-    """FileAccessProxy for text files (io.TextIOBase)"""
-
-
-class BufferedFileProxy(FileAccessProxy):
-    """FileAccessProxy for buffered binary files (io.BufferedIOBase)"""
-
-
-class RawFileProxy(FileAccessProxy):
-    """FileAccessProxy for raw/unbuffered binary files (io.RawIOBase)"""
-
-
-# Register one proxy class per io category so that isinstance(proxy, io.*)
-# keeps reporting the real file category without breaking attribute
-# delegation (subclassing io.* directly would resolve methods on the base
-# before __getattr__, hiding the real file's state).
-io.TextIOBase.register(TextFileProxy)
-io.BufferedIOBase.register(BufferedFileProxy)
-io.RawIOBase.register(RawFileProxy)
-
-
-def wrap_file_access(file, file_access, collector):
-    """Wrap a write-mode file object in the proxy matching its io category"""
-    if isinstance(file, io.TextIOBase):
-        return TextFileProxy(file, file_access, collector)
-    if isinstance(file, io.BufferedIOBase):
-        return BufferedFileProxy(file, file_access, collector)
-    if isinstance(file, io.RawIOBase):
-        return RawFileProxy(file, file_access, collector)
-    return FileAccessProxy(file, file_access, collector)
 
 
 class Collector(object):

--- a/src/noworkflow/now/collection/prov_execution/file_access_proxy.py
+++ b/src/noworkflow/now/collection/prov_execution/file_access_proxy.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2016 Universidade Federal Fluminense (UFF)
+# Copyright (c) 2016 Polytechnic Institute of New York University.
+# This file is part of noWorkflow.
+# Please, consult the license terms in the LICENSE file.
+"""Proxy that captures content_hash_after when a write-mode file is closed"""
+
+import os
+import io
+
+from ...persistence import content
+
+
+class FileAccessProxy(object):
+    """Proxy around a real file object.
+
+    Delegates every operation to the wrapped file and captures
+    ``content_hash_after`` at the moment the file is closed (explicit
+    ``close()`` or ``with`` block exit). This is required because the
+    ``open`` call is itself a noWorkflow activation that closes right after
+    returning the (just-truncated) file object; capturing the "after" hash
+    when that activation closes would always hash an empty file.
+    """
+    # pylint: disable=protected-access
+
+    def __init__(self, file, file_access, collector):
+        object.__setattr__(self, "_f", file)
+        object.__setattr__(self, "_fa", file_access)
+        object.__setattr__(self, "_collector", collector)
+
+    def _capture_after(self):
+        """Re-read the file from disk and store its content_hash_after once"""
+        file_access = self._fa
+        # The file is no longer open for the never-closed fallback in store().
+        self._collector.open_write_files.pop(file_access, None)
+        if (file_access.content_hash_after is None
+                and os.path.exists(file_access.name)):
+            with content.std_open(file_access.name, "rb") as fil:
+                file_access.content_hash_after = content.put(
+                    fil.read(), file_access.name
+                )
+        file_access.done = True
+
+    def close(self):
+        """Close the real file (flushing it) before capturing the hash"""
+        result = self._f.close()
+        self._capture_after()
+        return result
+
+    def __enter__(self):
+        self._f.__enter__()
+        return self
+
+    def __exit__(self, *exc):
+        result = self._f.__exit__(*exc)
+        self._capture_after()
+        return result
+
+    # Dunders that bypass __getattr__ must be delegated explicitly:
+    def __iter__(self):
+        return iter(self._f)
+
+    def __next__(self):
+        return next(self._f)
+
+    def write(self, *args, **kwargs):
+        return self._f.write(*args, **kwargs)
+
+    def read(self, *args, **kwargs):
+        return self._f.read(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._f, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._f, name, value)
+
+
+class TextFileProxy(FileAccessProxy):
+    """FileAccessProxy for text files (io.TextIOBase)"""
+
+
+class BufferedFileProxy(FileAccessProxy):
+    """FileAccessProxy for buffered binary files (io.BufferedIOBase)"""
+
+
+class RawFileProxy(FileAccessProxy):
+    """FileAccessProxy for raw/unbuffered binary files (io.RawIOBase)"""
+
+
+# Register one proxy class per io category so that isinstance(proxy, io.*)
+# keeps reporting the real file category without breaking attribute
+# delegation (subclassing io.* directly would resolve methods on the base
+# before __getattr__, hiding the real file's state).
+io.TextIOBase.register(TextFileProxy)
+io.BufferedIOBase.register(BufferedFileProxy)
+io.RawIOBase.register(RawFileProxy)
+
+
+def wrap_file_access(file, file_access, collector):
+    """Wrap a write-mode file object in the proxy matching its io category"""
+    if isinstance(file, io.TextIOBase):
+        return TextFileProxy(file, file_access, collector)
+    if isinstance(file, io.BufferedIOBase):
+        return BufferedFileProxy(file, file_access, collector)
+    if isinstance(file, io.RawIOBase):
+        return RawFileProxy(file, file_access, collector)
+    return FileAccessProxy(file, file_access, collector)

--- a/src/noworkflow/tests/prov_execution/test_file_access_execution.py
+++ b/src/noworkflow/tests/prov_execution/test_file_access_execution.py
@@ -14,7 +14,7 @@ import tempfile
 
 from future.utils import viewvalues
 
-from ...now.collection.prov_execution.collector import wrap_file_access
+from ...now.collection.prov_execution.file_access_proxy import wrap_file_access
 from ..collection_testcase import CollectionTestCase
 
 


### PR DESCRIPTION
The FileAccessProxy (and its TextFileProxy/BufferedFileProxy/RawFileProxy subclasses, the io category registrations, and wrap_file_access factory) were added to collector.py, which was already too large. Extract them into a dedicated file_access_proxy.py module and import wrap_file_access from there in the collector.

No behavior change: run_tests.py is still 100% green (339 tests, 1 skip, 0 failures). The regression test's import is updated to point at the new module.