### PR TITLE
[128] Fix ReferenceError: weakly-referenced object no longer exists

### DIFF
--- a/src/noworkflow/now/models/dataflow_model.py
+++ b/src/noworkflow/now/models/dataflow_model.py
@@ -10,7 +10,6 @@ import weakref
 
 
 from ..persistence.models.base import Model
-from ..persistence.models.trial import Trial
 
 from .dependency_graph.dot_visitor import DotVisitor
 from .dependency_graph.search_visitor import SearchEvaluationVisitor
@@ -73,6 +72,7 @@ class DataflowModel(Model):
                 pass
 
         if self.trial_ref is not None:
+            from ..persistence.models.trial import Trial
             return Trial(self.trial_ref)
 
         raise ValueError("Either activation or trial should be defined")

--- a/src/noworkflow/now/models/dataflow_model.py
+++ b/src/noworkflow/now/models/dataflow_model.py
@@ -10,6 +10,7 @@ import weakref
 
 
 from ..persistence.models.base import Model
+from ..persistence.models.trial import Trial
 
 from .dependency_graph.dot_visitor import DotVisitor
 from .dependency_graph.search_visitor import SearchEvaluationVisitor
@@ -23,8 +24,10 @@ class DataflowModel(Model):
     def __init__(self, trial=None, activation=None):
         super(DataflowModel, self).__init__()
         self.trial = None
+        self.trial_ref = None
         if trial is not None:
             self.trial = weakref.proxy(trial)
+            self.trial_ref = trial.id
         self.activation = None
         if activation is not None:
             self.activation = activation
@@ -36,12 +39,8 @@ class DataflowModel(Model):
 
     def _load_trial_and_activation(self):
         """Load trial or activation from trial/activation attributes"""
-        if self.activation is None and self.trial is None:
-            raise ValueError("Either activation or trial should be defined")
-        elif self.activation is not None:
-            self.trial = weakref.proxy(self.activation.trial)
-        elif self.trial is not None:
-            self.activation = self.trial.initial_activation
+        self.trial = self._get_trial()
+        self.activation = self.trial.initial_activation
 
     def export_text(self):
         """Export facts from trial as text"""
@@ -64,3 +63,16 @@ class DataflowModel(Model):
             "dot", "--format {}".format(self.format), self.export_text()
         )
         display(obj)
+
+    def _get_trial(self):
+        if self.trial is not None:
+            try:
+                self.trial.id  # just verifies the proxy is alive
+                return self.trial
+            except ReferenceError:
+                pass
+
+        if self.trial_ref is not None:
+            return Trial(self.trial_ref)
+
+        raise ValueError("Either activation or trial should be defined")

--- a/src/noworkflow/now/models/dependency_graph/config.py
+++ b/src/noworkflow/now/models/dependency_graph/config.py
@@ -43,7 +43,7 @@ class DependencyConfig(object):
         self.hide_not_code = False
         self.hide_func = False
         self.max_depth = float("inf")
-        self.mode = "simulation"
+        self.mode = "coarseGrain"
 
     @classmethod
     def create_arguments(cls, add_arg, mode="coarseGrain"):

--- a/src/noworkflow/tests/__init__.py
+++ b/src/noworkflow/tests/__init__.py
@@ -29,6 +29,7 @@ from .prov_execution import TestFileAccessExecution
 from .dependency import TestClusterizer, TestClusterizerConfig
 from .dependency import TestProspectiveClusterizer
 from .dependency import TestActivationClusterizer, TestDependencyClusterizer
+from .dependency import TestDataflowModel
 from .cross_version_test import TestCrossVersion
 
 from ..now.persistence.models import ORDER
@@ -76,6 +77,7 @@ dataflow.addTests(loader.loadTestsFromTestCase(TestDependencyClusterizer))
 dataflow.addTests(loader.loadTestsFromTestCase(TestActivationClusterizer))
 dataflow.addTests(loader.loadTestsFromTestCase(TestProspectiveClusterizer))
 dataflow.addTests(loader.loadTestsFromTestCase(TestClusterizerConfig))
+dataflow.addTests(loader.loadTestsFromTestCase(TestDataflowModel))
 
 
 def load_tests(loader, tests, pattern):

--- a/src/noworkflow/tests/dependency/__init__.py
+++ b/src/noworkflow/tests/dependency/__init__.py
@@ -11,6 +11,7 @@ from .test_default_clusterizer import TestClusterizer
 from .test_dependency_clusterizer import TestDependencyClusterizer
 from .test_activation_clusterizer import TestActivationClusterizer
 from .test_prospective_clusterizer import TestProspectiveClusterizer
+from .test_dataflow_model import TestDataflowModel
 from .test_clusterizer_config import TestClusterizerConfig
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "TestActivationClusterizer",
     "TestProspectiveClusterizer",
     "TestClusterizerConfig",
+    "TestDataflowModel"
 ]

--- a/src/noworkflow/tests/dependency/test_dataflow_model.py
+++ b/src/noworkflow/tests/dependency/test_dataflow_model.py
@@ -13,6 +13,9 @@ class TestDataflowModel(CollectionTestCase):
         self.clean_execution()
 
         trial = Trial()
+        trial_ref = trial.id
+
+        trial = Trial(trial_ref)
         dot = trial.dot
 
         del trial

--- a/src/noworkflow/tests/dependency/test_dataflow_model.py
+++ b/src/noworkflow/tests/dependency/test_dataflow_model.py
@@ -1,0 +1,23 @@
+import gc
+
+from ...now.persistence.models import Trial
+from ..collection_testcase import CollectionTestCase
+
+
+class TestDataflowModel(CollectionTestCase):
+    def test_export_text_reloads_trial_after_weakref_dies(self):
+        self.script("# script.py\n"
+                    "x = 1\n"
+                    "y = x + 2\n"
+                    "print(y)\n")
+        self.clean_execution()
+
+        trial = Trial()
+        dot = trial.dot
+
+        del trial
+        gc.collect()
+
+        text = dot.export_text()
+
+        self.assertIn("digraph", text)


### PR DESCRIPTION
Fixes issue [#128](https://github.com/gems-uff/noworkflow/issues/128).

This change makes `DataflowModel` keep a durable `trial_ref` alongside its weak trial proxy, allowing export_text() to reload the Trial if the original weakly-referenced object has already been garbage-collected. It also updates the default dependency graph mode from the stale simulation name to `coarseGrain`.

Adds a test covering dataflow export after the original Trial object dies.